### PR TITLE
fix: Do not send no_players_near.. if global/world disabled

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.20.1
 yarn_mappings=1.20.1+build.2
 loader_version=0.14.21
 # Mod Properties
-mod_version=1.9.1
+mod_version=1.9.2
 maven_group=me.vetustus.server
 archives_base_name=simplechat
 # Dependencies

--- a/src/main/java/me/vetustus/server/simplechat/SimpleChat.java
+++ b/src/main/java/me/vetustus/server/simplechat/SimpleChat.java
@@ -142,7 +142,9 @@ public class SimpleChat implements ModInitializer {
 //                }
             }
 
-            if (isPlayerLocalFound <= 1 && !isGlobalMessage && !isWorldMessage) {
+            if (isPlayerLocalFound <= 1
+                    && (config.isGlobalChatEnabled() && !isGlobalMessage)
+                    && (config.isWorldChatEnabled() && !isWorldMessage)) {
                 String noPlayerNearbyText = config.getNoPlayerNearbyText();
                 Text noPlayerNearbyTextResult = literal(translateChatColors('&', noPlayerNearbyText));
                 player.sendMessage(noPlayerNearbyTextResult, config.noPlayerNearbyActionBar());


### PR DESCRIPTION
There was an issue that the mod would send the "no_players_nearby_text" message even when the world and global chats where disabled in the configuraiton file.

So this commit resolves the issue by simply comparing against chat toggles when sending the notification.